### PR TITLE
chore(release): v1.0.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ The CLI follows a command-based architecture built on Commander.js:
   - **errors.ts**: Centralized error handling for ChartMogul API errors
   - **command-utils.ts**: Shared command helpers (`withErrorHandling`)
   - **dates.ts**: Date parsing and validation utilities
+  - **utils.ts**: Currency conversion (cents to dollars)
 - **src/types/**: TypeScript type definitions
 
 ### Authentication Flow
@@ -58,8 +59,9 @@ ChartMogul uses Basic Auth with API key:
 ### Output System
 
 All commands use `outputJson()` from src/lib/output.ts which:
-1. Formats as JSON (pretty or compact based on `--compact` flag)
-2. Writes to stdout
+1. Converts monetary values from cents to dollars (MRR, ARR, amounts, etc.)
+2. Formats as JSON (pretty or compact based on `--compact` flag)
+3. Writes to stdout
 
 ### Error Handling
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ chartmogul metrics mrr                    # Pretty-printed JSON
 chartmogul -c metrics mrr                 # Compact JSON (single line)
 ```
 
+**Monetary values are in dollars** (not ChartMogul's internal cents). An MRR of `100` means $100.
+
 Errors are also returned as JSON:
 
 ```json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stephendolan/chartmogul-cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A command-line interface for ChartMogul analytics",
   "type": "module",
   "main": "./dist/cli.js",

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,4 +1,5 @@
 import type { OutputOptions } from '../types/index.js';
+import { convertCentsToDollars } from './utils.js';
 
 let globalOutputOptions: OutputOptions = {};
 
@@ -7,9 +8,12 @@ export function setOutputOptions(options: OutputOptions): void {
 }
 
 export function outputJson(data: unknown, options: OutputOptions = {}): void {
+  const convertedData = convertCentsToDollars(data);
   const mergedOptions = { ...globalOutputOptions, ...options };
 
-  const jsonString = mergedOptions.compact ? JSON.stringify(data) : JSON.stringify(data, null, 2);
+  const jsonString = mergedOptions.compact
+    ? JSON.stringify(convertedData)
+    : JSON.stringify(convertedData, null, 2);
 
   console.log(jsonString);
 }

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { convertCentsToDollars } from './utils.js';
+
+describe('convertCentsToDollars', () => {
+  it('converts explicit _in_cents fields', () => {
+    const input = {
+      amount_in_cents: 1500,
+      discount_amount_in_cents: 200,
+      tax_amount_in_cents: 100,
+    };
+    const output = convertCentsToDollars(input);
+    expect(output).toEqual({
+      amount_in_cents: 15,
+      discount_amount_in_cents: 2,
+      tax_amount_in_cents: 1,
+    });
+  });
+
+  it('converts MRR/ARR fields', () => {
+    const input = {
+      mrr: 10000,
+      arr: 120000,
+      activity_mrr: 5000,
+      activity_arr: 60000,
+      activity_mrr_movement: 1000,
+    };
+    const output = convertCentsToDollars(input);
+    expect(output).toEqual({
+      mrr: 100,
+      arr: 1200,
+      activity_mrr: 50,
+      activity_arr: 600,
+      activity_mrr_movement: 10,
+    });
+  });
+
+  it('converts metric fields', () => {
+    const input = {
+      arpa: 5000,
+      asp: 10000,
+      ltv: 100000,
+      'new-biz': 2000,
+      expansion: 1000,
+      contraction: 500,
+      churn: 300,
+      reactivation: 200,
+    };
+    const output = convertCentsToDollars(input);
+    expect(output).toEqual({
+      arpa: 50,
+      asp: 100,
+      ltv: 1000,
+      'new-biz': 20,
+      expansion: 10,
+      contraction: 5,
+      churn: 3,
+      reactivation: 2,
+    });
+  });
+
+  it('preserves non-cents fields', () => {
+    const input = {
+      name: 'Customer',
+      customers: 100,
+      date: '2024-01-01',
+      currency: 'USD',
+    };
+    const output = convertCentsToDollars(input);
+    expect(output).toEqual(input);
+  });
+
+  it('handles nested objects', () => {
+    const input = {
+      entries: [
+        { date: '2024-01-01', mrr: 10000 },
+        { date: '2024-02-01', mrr: 12000 },
+      ],
+    };
+    const output = convertCentsToDollars(input);
+    expect(output).toEqual({
+      entries: [
+        { date: '2024-01-01', mrr: 100 },
+        { date: '2024-02-01', mrr: 120 },
+      ],
+    });
+  });
+
+  it('handles null and undefined', () => {
+    expect(convertCentsToDollars(null)).toBe(null);
+    expect(convertCentsToDollars(undefined)).toBe(undefined);
+  });
+
+  it('handles arrays', () => {
+    const input = [{ mrr: 1000 }, { mrr: 2000 }];
+    const output = convertCentsToDollars(input);
+    expect(output).toEqual([{ mrr: 10 }, { mrr: 20 }]);
+  });
+
+  it('handles fields ending with _in_cents suffix', () => {
+    const input = { custom_amount_in_cents: 5000 };
+    const output = convertCentsToDollars(input);
+    expect(output).toEqual({ custom_amount_in_cents: 50 });
+  });
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,42 @@
+function centsToDollars(cents: number): number {
+  return cents / 100;
+}
+
+const CENTS_FIELDS = new Set([
+  'amount_in_cents',
+  'discount_amount_in_cents',
+  'tax_amount_in_cents',
+  'mrr',
+  'arr',
+  'arpa',
+  'asp',
+  'ltv',
+  'activity_mrr',
+  'activity_arr',
+  'activity_mrr_movement',
+  'new-biz',
+  'expansion',
+  'contraction',
+  'churn',
+  'reactivation',
+]);
+
+function isCentsField(fieldName: string): boolean {
+  return CENTS_FIELDS.has(fieldName) || fieldName.endsWith('_in_cents');
+}
+
+export function convertCentsToDollars(data: unknown): unknown {
+  if (data === null || data === undefined) return data;
+  if (Array.isArray(data)) return data.map(convertCentsToDollars);
+  if (typeof data !== 'object') return data;
+
+  const converted: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (isCentsField(key) && typeof value === 'number') {
+      converted[key] = centsToDollars(value);
+    } else {
+      converted[key] = convertCentsToDollars(value);
+    }
+  }
+  return converted;
+}


### PR DESCRIPTION
## Summary

Patch release converting monetary values from cents to dollars in CLI output. ChartMogul's API returns values in cents, but the CLI now displays them in dollars for better user experience.

## Problem

ChartMogul returns all monetary values (MRR, ARR, amounts) in cents. Users had to mentally divide by 100, making the CLI output less intuitive for quick analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)