### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stephendolan/chartmogul-cli",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A command-line interface for ChartMogul analytics",
   "type": "module",
   "main": "./dist/cli.js",

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import { client } from '../lib/api-client.js';
 import { auth } from '../lib/auth.js';
+import { convertCentsToDollars } from '../lib/utils.js';
 
 const server = new McpServer({
   name: 'chartmogul',
@@ -10,7 +11,8 @@ const server = new McpServer({
 });
 
 function jsonResponse(data: unknown) {
-  return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+  const converted = convertCentsToDollars(data);
+  return { content: [{ type: 'text' as const, text: JSON.stringify(converted, null, 2) }] };
 }
 
 const dateRangeSchema = {


### PR DESCRIPTION
## Summary

This minor release fixes monetary value conversion in the MCP server. The MCP server now converts cents to dollars in all responses, matching the CLI behavior and preventing AI consumers from misinterpreting monetary values.

## Problem

The MCP server was returning monetary values in cents while the CLI was displaying them in dollars. This inconsistency caused AI systems consuming the MCP server to misinterpret financial data, leading to incorrect analysis and reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)