### PR TITLE
chore(release): v1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stephendolan/chartmogul-cli",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A command-line interface for ChartMogul analytics",
   "type": "module",
   "main": "./dist/cli.js",

--- a/src/commands/activities.ts
+++ b/src/commands/activities.ts
@@ -14,6 +14,7 @@ export function createActivitiesCommand(): Command {
     .option('--type <type>', 'Activity type (new_biz, expansion, contraction, churn, reactivation)')
     .option('--page <number>', 'Page number')
     .option('--per-page <number>', 'Results per page')
+    .option('--enrich', 'Include customer tenure data (customer-since, customer-tenure-months)')
     .action(
       withErrorHandling(
         async (options: {
@@ -22,14 +23,18 @@ export function createActivitiesCommand(): Command {
           type?: string;
           page?: string;
           perPage?: string;
+          enrich?: boolean;
         }) => {
-          const result = await client.listActivities({
+          const params = {
             'start-date': options.startDate,
             'end-date': options.endDate,
             type: options.type,
             page: options.page ? parseInt(options.page, 10) : undefined,
             per_page: options.perPage ? parseInt(options.perPage, 10) : undefined,
-          });
+          };
+          const result = options.enrich
+            ? await client.listActivitiesEnriched(params)
+            : await client.listActivities(params);
           outputJson(result);
         }
       )

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { convertCentsToDollars } from './utils.js';
 
 describe('convertCentsToDollars', () => {
-  it('converts explicit _in_cents fields', () => {
+  it('converts _in_cents fields and strips suffix', () => {
     const input = {
       amount_in_cents: 1500,
       discount_amount_in_cents: 200,
@@ -10,9 +10,9 @@ describe('convertCentsToDollars', () => {
     };
     const output = convertCentsToDollars(input);
     expect(output).toEqual({
-      amount_in_cents: 15,
-      discount_amount_in_cents: 2,
-      tax_amount_in_cents: 1,
+      amount: 15,
+      discount_amount: 2,
+      tax_amount: 1,
     });
   });
 
@@ -31,6 +31,20 @@ describe('convertCentsToDollars', () => {
       activity_mrr: 50,
       activity_arr: 600,
       activity_mrr_movement: 10,
+    });
+  });
+
+  it('converts hyphenated activity fields', () => {
+    const input = {
+      'activity-mrr': 5000,
+      'activity-arr': 60000,
+      'activity-mrr-movement': 1000,
+    };
+    const output = convertCentsToDollars(input);
+    expect(output).toEqual({
+      'activity-mrr': 50,
+      'activity-arr': 600,
+      'activity-mrr-movement': 10,
     });
   });
 
@@ -96,9 +110,9 @@ describe('convertCentsToDollars', () => {
     expect(output).toEqual([{ mrr: 10 }, { mrr: 20 }]);
   });
 
-  it('handles fields ending with _in_cents suffix', () => {
+  it('strips _in_cents suffix from custom fields', () => {
     const input = { custom_amount_in_cents: 5000 };
     const output = convertCentsToDollars(input);
-    expect(output).toEqual({ custom_amount_in_cents: 50 });
+    expect(output).toEqual({ custom_amount: 50 });
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,6 +14,9 @@ const CENTS_FIELDS = new Set([
   'activity_mrr',
   'activity_arr',
   'activity_mrr_movement',
+  'activity-mrr',
+  'activity-arr',
+  'activity-mrr-movement',
   'new-biz',
   'expansion',
   'contraction',
@@ -25,6 +28,10 @@ function isCentsField(fieldName: string): boolean {
   return CENTS_FIELDS.has(fieldName) || fieldName.endsWith('_in_cents');
 }
 
+function normalizeFieldName(fieldName: string): string {
+  return fieldName.replace(/_in_cents$/, '');
+}
+
 export function convertCentsToDollars(data: unknown): unknown {
   if (data === null || data === undefined) return data;
   if (Array.isArray(data)) return data.map(convertCentsToDollars);
@@ -33,7 +40,7 @@ export function convertCentsToDollars(data: unknown): unknown {
   const converted: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(data)) {
     if (isCentsField(key) && typeof value === 'number') {
-      converted[key] = centsToDollars(value);
+      converted[normalizeFieldName(key)] = centsToDollars(value);
     } else {
       converted[key] = convertCentsToDollars(value);
     }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -96,9 +96,15 @@ server.tool(
       .describe('Activity type filter'),
     page: z.number().optional().describe('Page number'),
     perPage: z.number().optional().describe('Results per page'),
+    enrich: z.boolean().optional().describe('Include customer tenure data (customer-since, customer-tenure-months)'),
   },
-  async ({ startDate, endDate, type, page, perPage }) =>
-    jsonResponse(await client.listActivities({ 'start-date': startDate, 'end-date': endDate, type, page, per_page: perPage }))
+  async ({ startDate, endDate, type, page, perPage, enrich }) => {
+    const params = { 'start-date': startDate, 'end-date': endDate, type, page, per_page: perPage };
+    const result = enrich
+      ? await client.listActivitiesEnriched(params)
+      : await client.listActivities(params);
+    return jsonResponse(result);
+  }
 );
 
 server.tool(
@@ -113,6 +119,13 @@ server.tool(
   'Get detailed information about a specific customer',
   { uuid: z.string().describe('Customer UUID') },
   async ({ uuid }) => jsonResponse(await client.getCustomer(uuid))
+);
+
+server.tool(
+  'get_customers_batch',
+  'Get detailed information about multiple customers in one call',
+  { uuids: z.array(z.string()).describe('Array of customer UUIDs') },
+  async ({ uuids }) => jsonResponse(await client.getCustomersBatch(uuids))
 );
 
 server.tool(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,6 +39,7 @@ export interface Customer {
   free_trial_started_at?: string;
   status: string;
   customer_since?: string;
+  'customer-since'?: string;
   mrr: number;
   arr: number;
   billing_system_url?: string;
@@ -105,11 +106,11 @@ export interface LineItem {
   prorated?: boolean;
   service_period_start: string;
   service_period_end: string;
-  amount_in_cents: number;
+  amount: number;
   quantity?: number;
   discount_code?: string;
-  discount_amount_in_cents?: number;
-  tax_amount_in_cents?: number;
+  discount_amount?: number;
+  tax_amount?: number;
   account_code?: string;
 }
 
@@ -148,11 +149,20 @@ export interface Activity {
   date: string;
   type: string;
   description: string;
-  activity_mrr: number;
-  activity_mrr_movement: number;
-  activity_arr: number;
+  'activity-mrr': number;
+  'activity-mrr-movement': number;
+  'activity-arr': number;
   currency: string;
-  currency_sign: string;
+  'customer-name': string;
+  'customer-uuid': string;
+  'customer-external-id': string;
+  'subscription-external-id'?: string;
+  'plan-external-id'?: string;
+}
+
+export interface EnrichedActivity extends Activity {
+  'customer-since'?: string;
+  'customer-tenure-months'?: number;
 }
 
 export interface PaginatedResponse<T> {


### PR DESCRIPTION
## Release v1.4.0

### Features
- Add `--enrich` option to activities command with customer tenure data (`customer-since`, `customer-tenure-months`)
- Add `getCustomersBatch` and `listActivitiesEnriched` methods to API client
- Add `get_customers_batch` MCP tool for batch customer lookups
- Strip `_in_cents` suffix from currency field names in CLI output (e.g., `amount_in_cents` → `amount`)

### Improvements
- Update Activity types to use hyphenated API field names
- Add hyphenated activity fields (`activity-mrr`, `activity-arr`, `activity-mrr-movement`) to cents conversion

---
🤖 Generated with [Claude Code](https://claude.ai/code)