### PR TITLE
chore(release): v1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stephendolan/chartmogul-cli",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "A command-line interface for ChartMogul analytics",
   "type": "module",
   "main": "./dist/cli.js",

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -9,15 +9,25 @@ const toolRegistry = [
   { name: 'get_all_metrics', description: 'Get all revenue metrics (MRR, ARR, ARPA, churn rates, LTV, customer count) for a date range' },
   { name: 'get_mrr', description: 'Get Monthly Recurring Revenue (MRR) for a date range' },
   { name: 'get_arr', description: 'Get Annual Recurring Revenue (ARR) for a date range' },
+  { name: 'get_arpa', description: 'Get Average Revenue Per Account (ARPA) for a date range' },
+  { name: 'get_asp', description: 'Get Average Sale Price (ASP) for a date range' },
+  { name: 'get_customer_count', description: 'Get customer count over a date range' },
   { name: 'get_customer_churn_rate', description: 'Get customer churn rate for a date range' },
   { name: 'get_mrr_churn_rate', description: 'Get MRR churn rate for a date range' },
+  { name: 'get_ltv', description: 'Get Customer Lifetime Value (LTV) for a date range' },
   { name: 'list_activities', description: 'List subscription activities (new business, expansion, contraction, churn)' },
   { name: 'search_customers', description: 'Search for customers by email address' },
   { name: 'get_customer', description: 'Get detailed information about a specific customer' },
   { name: 'get_customers_batch', description: 'Get detailed information about multiple customers in one call' },
   { name: 'get_customer_activities', description: 'Get subscription activities for a specific customer' },
   { name: 'get_customer_subscriptions', description: 'Get active subscriptions for a specific customer' },
-  { name: 'list_customers', description: 'List all customers with optional filtering' },
+  { name: 'list_customers', description: 'List all customers with optional filtering by status, external ID, or data source' },
+  { name: 'list_invoices', description: 'List invoices with optional filtering by customer, data source, or external ID' },
+  { name: 'get_invoice', description: 'Get detailed information about a specific invoice' },
+  { name: 'list_plans', description: 'List subscription plans with optional filtering by data source' },
+  { name: 'get_plan', description: 'Get detailed information about a specific plan' },
+  { name: 'list_data_sources', description: 'List all configured data sources' },
+  { name: 'get_data_source', description: 'Get detailed information about a specific data source' },
   { name: 'get_account', description: 'Get ChartMogul account information' },
   { name: 'check_auth', description: 'Check if ChartMogul authentication is configured' },
 ];
@@ -102,6 +112,54 @@ server.tool(
 );
 
 server.tool(
+  'get_arpa',
+  'Get Average Revenue Per Account (ARPA) for a date range',
+  {
+    startDate: dateRangeSchema.startDate,
+    endDate: dateRangeSchema.endDate,
+    interval: dateRangeSchema.interval,
+  },
+  async ({ startDate, endDate, interval }) =>
+    jsonResponse(await client.getArpa({ 'start-date': startDate, 'end-date': endDate, interval }))
+);
+
+server.tool(
+  'get_asp',
+  'Get Average Sale Price (ASP) for a date range',
+  {
+    startDate: dateRangeSchema.startDate,
+    endDate: dateRangeSchema.endDate,
+    interval: dateRangeSchema.interval,
+  },
+  async ({ startDate, endDate, interval }) =>
+    jsonResponse(await client.getAsp({ 'start-date': startDate, 'end-date': endDate, interval }))
+);
+
+server.tool(
+  'get_customer_count',
+  'Get customer count over a date range',
+  {
+    startDate: dateRangeSchema.startDate,
+    endDate: dateRangeSchema.endDate,
+    interval: dateRangeSchema.interval,
+  },
+  async ({ startDate, endDate, interval }) =>
+    jsonResponse(await client.getCustomerCount({ 'start-date': startDate, 'end-date': endDate, interval }))
+);
+
+server.tool(
+  'get_ltv',
+  'Get Customer Lifetime Value (LTV) for a date range',
+  {
+    startDate: dateRangeSchema.startDate,
+    endDate: dateRangeSchema.endDate,
+    interval: dateRangeSchema.interval,
+  },
+  async ({ startDate, endDate, interval }) =>
+    jsonResponse(await client.getLtv({ 'start-date': startDate, 'end-date': endDate, interval }))
+);
+
+server.tool(
   'list_activities',
   'List subscription activities (new business, expansion, contraction, churn)',
   {
@@ -166,14 +224,70 @@ server.tool(
 
 server.tool(
   'list_customers',
-  'List all customers with optional filtering',
+  'List all customers with optional filtering by status, external ID, or data source',
   {
     status: z.enum(['Lead', 'Active', 'Past Due', 'Cancelled']).optional().describe('Customer status'),
+    externalId: z.string().optional().describe('Filter by external ID'),
+    dataSourceUuid: z.string().optional().describe('Filter by data source UUID'),
     page: z.number().optional().describe('Page number'),
     perPage: z.number().optional().describe('Results per page'),
   },
-  async ({ status, page, perPage }) =>
-    jsonResponse(await client.listCustomers({ status, page, per_page: perPage }))
+  async ({ status, externalId, dataSourceUuid, page, perPage }) =>
+    jsonResponse(await client.listCustomers({ status, external_id: externalId, data_source_uuid: dataSourceUuid, page, per_page: perPage }))
+);
+
+server.tool(
+  'list_invoices',
+  'List invoices with optional filtering by customer, data source, or external ID',
+  {
+    customerUuid: z.string().optional().describe('Filter by customer UUID'),
+    dataSourceUuid: z.string().optional().describe('Filter by data source UUID'),
+    externalId: z.string().optional().describe('Filter by external ID'),
+    page: z.number().optional().describe('Page number'),
+    perPage: z.number().optional().describe('Results per page'),
+  },
+  async ({ customerUuid, dataSourceUuid, externalId, page, perPage }) =>
+    jsonResponse(await client.listInvoices({ customer_uuid: customerUuid, data_source_uuid: dataSourceUuid, external_id: externalId, page, per_page: perPage }))
+);
+
+server.tool(
+  'get_invoice',
+  'Get detailed information about a specific invoice',
+  { uuid: z.string().describe('Invoice UUID') },
+  async ({ uuid }) => jsonResponse(await client.getInvoice(uuid))
+);
+
+server.tool(
+  'list_plans',
+  'List subscription plans with optional filtering by data source',
+  {
+    dataSourceUuid: z.string().optional().describe('Filter by data source UUID'),
+    page: z.number().optional().describe('Page number'),
+    perPage: z.number().optional().describe('Results per page'),
+  },
+  async ({ dataSourceUuid, page, perPage }) =>
+    jsonResponse(await client.listPlans({ data_source_uuid: dataSourceUuid, page, per_page: perPage }))
+);
+
+server.tool(
+  'get_plan',
+  'Get detailed information about a specific plan',
+  { uuid: z.string().describe('Plan UUID') },
+  async ({ uuid }) => jsonResponse(await client.getPlan(uuid))
+);
+
+server.tool(
+  'list_data_sources',
+  'List all configured data sources',
+  {},
+  async () => jsonResponse(await client.listDataSources())
+);
+
+server.tool(
+  'get_data_source',
+  'Get detailed information about a specific data source',
+  { uuid: z.string().describe('Data source UUID') },
+  async ({ uuid }) => jsonResponse(await client.getDataSource(uuid))
 );
 
 server.tool(


### PR DESCRIPTION
## Summary
- Add missing MCP tools to reach parity with CLI/API client
- Add `externalId` and `dataSourceUuid` filters to `list_customers`
- Add 4 metric tools: `get_arpa`, `get_asp`, `get_customer_count`, `get_ltv`
- Add 6 resource tools: `list_invoices`, `get_invoice`, `list_plans`, `get_plan`, `list_data_sources`, `get_data_source`

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test` passes (20 tests)
- [x] `bun run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)