### PR TITLE
fix: use cursor-based pagination for activities endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stephendolan/chartmogul-cli",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A command-line interface for ChartMogul analytics",
   "type": "module",
   "main": "./dist/cli.js",

--- a/src/commands/activities.ts
+++ b/src/commands/activities.ts
@@ -12,7 +12,7 @@ export function createActivitiesCommand(): Command {
     .option('--start-date <date>', 'Start date (YYYY-MM-DD)')
     .option('--end-date <date>', 'End date (YYYY-MM-DD)')
     .option('--type <type>', 'Activity type (new_biz, expansion, contraction, churn, reactivation)')
-    .option('--page <number>', 'Page number')
+    .option('--cursor <cursor>', 'Cursor for next page (from previous response)')
     .option('--per-page <number>', 'Results per page')
     .option('--enrich', 'Include customer tenure data (customer-since, customer-tenure-months)')
     .action(
@@ -21,7 +21,7 @@ export function createActivitiesCommand(): Command {
           startDate?: string;
           endDate?: string;
           type?: string;
-          page?: string;
+          cursor?: string;
           perPage?: string;
           enrich?: boolean;
         }) => {
@@ -29,8 +29,8 @@ export function createActivitiesCommand(): Command {
             'start-date': options.startDate,
             'end-date': options.endDate,
             type: options.type,
-            page: options.page ? parseInt(options.page, 10) : undefined,
-            per_page: options.perPage ? parseInt(options.perPage, 10) : undefined,
+            cursor: options.cursor,
+            'per-page': options.perPage ? parseInt(options.perPage, 10) : undefined,
           };
           const result = options.enrich
             ? await client.listActivitiesEnriched(params)

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -12,9 +12,19 @@ import type {
   EnrichedActivity,
   CustomerListResponse,
   PaginatedResponse,
+  CursorPaginatedResponse,
 } from '../types/index.js';
 
 const API_BASE = 'https://api.chartmogul.com/v1';
+
+type ActivityListParams = {
+  'start-date'?: string;
+  'end-date'?: string;
+  type?: string;
+  cursor?: string;
+  'per-page'?: number;
+};
+
 const MS_PER_MONTH = 1000 * 60 * 60 * 24 * 30.44;
 
 function calculateTenureMonths(activityDate: string, customerSince: string): number {
@@ -215,27 +225,13 @@ export class ChartMogulClient {
     return this.request<MetricsResponse>('GET', '/metrics/all', { params });
   }
 
-  async listActivities(
-    params: {
-      'start-date'?: string;
-      'end-date'?: string;
-      type?: string;
-      page?: number;
-      per_page?: number;
-    } = {}
-  ) {
-    return this.request<PaginatedResponse<Activity>>('GET', '/activities', { params });
+  async listActivities(params: ActivityListParams = {}) {
+    return this.request<CursorPaginatedResponse<Activity>>('GET', '/activities', { params });
   }
 
   async listActivitiesEnriched(
-    params: {
-      'start-date'?: string;
-      'end-date'?: string;
-      type?: string;
-      page?: number;
-      per_page?: number;
-    } = {}
-  ): Promise<PaginatedResponse<EnrichedActivity>> {
+    params: ActivityListParams = {}
+  ): Promise<CursorPaginatedResponse<EnrichedActivity>> {
     const activities = await this.listActivities(params);
 
     const uniqueCustomerUuids = [

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -169,12 +169,12 @@ server.tool(
       .enum(['new-biz', 'expansion', 'contraction', 'churn', 'reactivation'])
       .optional()
       .describe('Activity type filter'),
-    page: z.number().optional().describe('Page number'),
+    cursor: z.string().optional().describe('Cursor for next page (from previous response)'),
     perPage: z.number().optional().describe('Results per page'),
     enrich: z.boolean().optional().describe('Include customer tenure data (customer-since, customer-tenure-months)'),
   },
-  async ({ startDate, endDate, type, page, perPage, enrich }) => {
-    const params = { 'start-date': startDate, 'end-date': endDate, type, page, per_page: perPage };
+  async ({ startDate, endDate, type, cursor, perPage, enrich }) => {
+    const params = { 'start-date': startDate, 'end-date': endDate, type, cursor, 'per-page': perPage };
     const result = enrich
       ? await client.listActivitiesEnriched(params)
       : await client.listActivities(params);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -174,6 +174,13 @@ export interface PaginatedResponse<T> {
   total_pages?: number;
 }
 
+export interface CursorPaginatedResponse<T> {
+  entries: T[];
+  has_more: boolean;
+  per_page: number;
+  cursor: string;
+}
+
 export interface CustomerListResponse {
   entries: Customer[];
   has_more: boolean;


### PR DESCRIPTION
## Summary

- Activities API uses cursor-based pagination, not page numbers. `page=2` was silently ignored, returning identical results as page 1.
- Replace `--page` with `--cursor` across CLI command, MCP server, and API client
- Use `per-page` (hyphenated) to match ChartMogul's API parameter naming

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)