### PR TITLE
chore(release): v1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stephendolan/chartmogul-cli",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A command-line interface for ChartMogul analytics",
   "type": "module",
   "main": "./dist/cli.js",


### PR DESCRIPTION
## Summary
- Patch release bumping version from 1.7.0 to 1.7.1
- Includes improved `get_customer` error messaging and parameter validation for non-UUID IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)